### PR TITLE
Test and tweak pydds to better minimize data requirements.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
           python3 -m pip install -U -r requirements.txt
 
     - name: Test
-      run: cd autoortho && pytest test_getortho.py 
+      run: cd autoortho && pytest test_getortho.py test_pydds.py 
 
 
   test-windows:
@@ -39,4 +39,4 @@ jobs:
           py -m pip install -U -r requirements.txt
 
     - name: Test
-      run: cd autoortho && py -m pytest test_getortho.py 
+      run: cd autoortho && py -m pytest test_getortho.py test_pydds.py

--- a/autoortho/getortho.py
+++ b/autoortho/getortho.py
@@ -277,7 +277,7 @@ class Tile(object):
     col = -1
     maptype = None
     zoom = -1
-    min_zoom = 12
+    min_zoom = 11
     cache_dir = './cache'
     width = 16
     height = 16
@@ -552,6 +552,13 @@ class Tile(object):
                     log.debug(f"TILE: mip start: {mipmap.startpos}, mip end: {mipmap.endpos}, offset: {offset}, len: {length}")
                     if mipmap.startpos <= offset and (offset + length) < mipmap.endpos:
                         # Offset seek is in middle of mipmap.  Check if retrieval needed"
+                        #
+                        # The requested offset is equal to or after this mipmap's starting position
+                        # AND the offset + length is before the end.
+                        #
+                        # This should be a read in the middle of a mipmap somewhere.  Fetch if needed.
+                        #
+
                         log.debug(f"TILE: Detected middle read for mipmap {mipmap.idx}")
                         if not mipmap.retrieved:
                             log.debug(f"TILE: Retrieve {mipmap.idx}")
@@ -559,10 +566,19 @@ class Tile(object):
                         break
                     elif offset <= mipmap.startpos < (offset + length):
                         # Offset is before mipmap start, length is after start.  Check if retrieval is needed
-                        log.debug(f"TILE: Detected spanning read for {self} mipmap {mipmap.idx}. Get prior mipmap")
+                        #
+                        # The requested offset is equal to or before this mipmap's starting position
+                        # AND the offset + length is after the starting position.
+                        #
+                        # This indicates a read that starts before this mimap and continues somewhere into this
+                        # mipmap.  Fetch if needed.
+
+
+                        #log.debug(f"TILE: Detected spanning read for {self} mipmap {mipmap.idx}. Get prior mipmap")
                         #log.info(f"TILE: Retrieve mipmap {mipmap.idx - 1}")
-                        self.get_mipmap(mipmap.idx-1)
-                        #self.get_mipmap(mipmap.idx)
+                        #self.get_mipmap(mipmap.idx-1)
+                        log.debug(f"TILE: Detected spanning read for {self} mipmap {mipmap.idx}. Get mipmap")
+                        self.get_mipmap(mipmap.idx)
                         # if not mipmap.retrieved:
                         #     log.info(f"TILE: Retrieve {mipmap.idx}")
                         #     self.get_mipmap(mipmap.idx)

--- a/autoortho/test_pydds.py
+++ b/autoortho/test_pydds.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+
+import os
+import pytest
+import pydds
+
+from PIL import Image
+TESTPNG=os.path.join('testfiles', 'test_tile.png')
+
+def test_dds_conv(tmpdir):
+    timg = Image.open(TESTPNG)
+    outpath = os.path.join(tmpdir, 'test_tile.dds')
+    pydds.to_dds(timg, outpath)
+    
+    expectedbytes = 22369744
+    actualbytes = os.path.getsize(outpath)
+
+    assert expectedbytes == actualbytes
+    
+    stat = os.stat(outpath)
+    print(stat)
+    # We should have blocks to cover the full size of the image
+    assert stat.st_blocks*512 >= expectedbytes
+
+
+def test_empty_dds(tmpdir):
+    outpath = os.path.join(tmpdir, 'test_empty.dds')
+    dds = pydds.DDS(4096, 4096)
+    dds.write(outpath)
+    
+    expectedbytes = 22369744
+    actualbytes = os.path.getsize(outpath)
+    assert expectedbytes == actualbytes
+
+    stat = os.stat(outpath)
+    print(stat)
+    # Sparse file should have allocated space smaller than filesize
+    assert stat.st_blocks*512 < expectedbytes
+
+
+def test_mid_dds(tmpdir):
+    outpath = os.path.join(tmpdir, 'test_empty.dds')
+    timg = Image.open(TESTPNG)
+    dds = pydds.DDS(4096, 4096)
+    dds.gen_mipmaps(timg, 4)
+    
+    for m in dds.mipmap_list:
+        if m.idx >= 4:
+            assert m.retrieved == True
+            assert m.databuffer is not None
+        else:
+            assert m.retrieved == False
+            assert m.databuffer is None
+
+def test_read_mm0(tmpdir):
+    outpath = os.path.join(tmpdir, 'test_mm0.dds')
+    timg = Image.open(TESTPNG)
+    dds = pydds.DDS(4096, 4096)
+
+    dds.gen_mipmaps(timg)
+
+    data = dds.read(1024)
+    assert data
+
+
+def test_read_mid(tmpdir):
+    outpath = os.path.join(tmpdir, 'test_read_mid.dds')
+    timg = Image.open(TESTPNG)
+    dds = pydds.DDS(4096, 4096)
+
+    dds.gen_mipmaps(timg, 4)
+
+    dds.seek(22282368)
+    data1 = dds.read(1024)
+    assert data1
+    assert len(data1) == 1024
+
+    dds.seek(22282240)
+    data2 = dds.read(1024)
+    assert data2
+    assert len(data2) == 1024
+
+    # Since we started at different points, these should be different
+    assert data1[:512] != data2[:512]
+
+    # The ends should be identical
+    assert data1[0:384] == data2[128:512]
+
+    # The beginning portion should be empty
+    assert data2[:128] == b'\x00'*128
+
+    dds.write(outpath)
+    expectedbytes = 22369744
+    actualbytes = os.path.getsize(outpath)
+    assert expectedbytes == actualbytes
+
+
+#assert False
+
+

--- a/autoortho/test_pydds.py
+++ b/autoortho/test_pydds.py
@@ -46,9 +46,11 @@ def test_empty_dds(tmpdir):
     actualbytes = os.path.getsize(outpath)
     assert expectedbytes == actualbytes
 
-    # Sparse file should have allocated space smaller than filesize
-    ondisk_size = file_disksize(outpath)
-    assert ondisk_size < expectedbytes
+    # Windows doesn't support sparse files well, unfortunately.
+    if not platform.system().lower() == 'windows':
+        # Sparse file should have allocated space smaller than filesize
+        ondisk_size = file_disksize(outpath)
+        assert ondisk_size < expectedbytes
 
 
 def test_mid_dds(tmpdir):


### PR DESCRIPTION
If the start of data precedes the requested mipmap, do not attempt to retrieve the prior mipmap.  Instead fill the missing data with nulls.