### PR TITLE
Cleanup of winfsp module

### DIFF
--- a/autoortho/aoconfig.py
+++ b/autoortho/aoconfig.py
@@ -66,7 +66,7 @@ compressor = ISPC
 threading = True
 
 [winfsp]
-
+cache_dds = False
 """
 
     def __init__(self):

--- a/autoortho/autoortho_winfsp.py
+++ b/autoortho/autoortho_winfsp.py
@@ -198,7 +198,7 @@ class AutoorthoOperations(BaseFileSystemOperations):
     get_size_file_cnt = 0
     get_size_tile_cnt = 0
 
-    def __init__(self, root, volume_label, tile_cache, read_only=False):
+    def __init__(self, root, volume_label, tile_cache):
         super().__init__()
         if len(volume_label) > 31:
             raise ValueError("`volume_label` must be 31 characters long max")
@@ -213,7 +213,6 @@ class AutoorthoOperations(BaseFileSystemOperations):
             "volume_label": volume_label,
         }
 
-        self.read_only = read_only
         self.root = root
         self._root_path = PureWindowsPath("/")
         self.root_security_descr = SecurityDescriptor.from_string("O:BAG:BAD:P(A;;FA;;;SY)(A;;FA;;;BA)(A;;FA;;;WD)")
@@ -362,6 +361,7 @@ def create_file_system(
         str(mountpoint),
         operations,
         sector_size=512,
+        read_only_volume = 1,
         sectors_per_allocation_unit=1,
         volume_creation_time=filetime_now(),
         volume_serial_number=0,

--- a/autoortho/autoortho_winfsp.py
+++ b/autoortho/autoortho_winfsp.py
@@ -1,12 +1,12 @@
-"""A memory file system implemented on top of winfspy.
-
-Useful for testing and as a reference.
+"""
+A virtual file system that serves .dds files from a tile cache
 """
 
 import os
 import re
 import sys
 import time
+import logging
 import argparse
 import threading
 import traceback
@@ -32,12 +32,6 @@ from winfspy.plumbing.security_descriptor import SecurityDescriptor
 
 import getortho
 from aoconfig import CFG
-from winfsp_shim import OperationsShim
-import flighttrack
-
-import logging
-log = logging.getLogger(__name__)
-
 
 def operation(fn):
     """Decorator for file system operations.
@@ -68,7 +62,7 @@ def operation(fn):
 
 
 class BaseFileObj:
-    
+
     @property
     def name(self):
         """File name, without the path"""
@@ -109,35 +103,101 @@ class BaseFileObj:
 
 
 class FileObj(BaseFileObj):
-
-    allocation_unit = 4096
-    #tile = None
-    tile_id = None
-
     def __init__(self, path, attributes, security_descriptor, allocation_size=0):
         super().__init__(path, attributes, security_descriptor)
-        #self.data = bytearray(allocation_size)
         self.attributes |= FILE_ATTRIBUTE.FILE_ATTRIBUTE_ARCHIVE
         assert not self.attributes & FILE_ATTRIBUTE.FILE_ATTRIBUTE_DIRECTORY
 
+class OpenedTileObj:
+    tile = None
+    fh = None
 
-class FolderObj(BaseFileObj):
-    def __init__(self, path, attributes, security_descriptor):
-        super().__init__(path, attributes, security_descriptor)
-        self.allocation_size = 0
-        assert self.attributes & FILE_ATTRIBUTE.FILE_ATTRIBUTE_DIRECTORY
-
-
-class OpenedObj:
-    def __init__(self, file_obj, handle):
+    def __init__(self, file_obj, row, col, maptype, zoom, fsops):
         self.file_obj = file_obj
-        self.handle = handle
+        self.row = row
+        self.col = col
+        self.maptype = maptype
+        self.zoom = zoom
+        self.fsops = fsops
 
     def __repr__(self):
         return f"{type(self).__name__}:{self.file_obj.file_name}"
 
+    def close(self):
+        if self.tile != None:
+            self.fsops.tc._close_tile(self.row, self.col, self.maptype, self.zoom)
+            self.tile = None
 
-class AutoorthoOperations(OperationsShim):
+        if self.fh != None:
+            self.fh.close()
+            self.fh = None
+
+    def read(self, offset, length):
+        self.fsops.read_tile_cnt += 1
+        if offset == 0 and length < 40000:
+            self.fsops.read_tile_short_cnt += 1
+
+        # delayed open to make get_size cheap
+        if self.fh == None and self.tile == None:
+            dds_name = self.fsops.cache_dir + self.file_obj.file_name
+            if os.path.exists(dds_name):
+                print(f"DIRECT ACCESS: {dds_name}")
+                self.fh = open(dds_name, "rb")
+                self.fsops.open_tile_direct_cnt += 1
+
+        if self.fh == None and self.tile == None:
+            self.tile = self.fsops.tc._get_tile(self.row, self.col, self.maptype, self.zoom)
+            #print(f"Open: {self.tile}")
+            self.fsops.open_tile_cache_cnt += 1
+
+        if self.fh != None:
+            self.fh.seek(offset)
+            return self.fh.read(length)
+
+        if self.tile != None:
+            return self.tile.read_dds_bytes(offset, length)
+
+    def get_size(self):
+        self.fsops.get_size_tile_cnt += 1
+        return 22369744
+
+class OpenedFileObj:
+    def __init__(self, file_obj, handle, fsops):
+        self.file_obj = file_obj
+        self.handle = handle
+        self.fsops = fsops
+
+    def __repr__(self):
+        return f"{type(self).__name__}:{self.file_obj.file_name}"
+
+    def close(self):
+        if self.handle != None:
+            #print(f"Closing {self}  FH: {self.handle}")
+            self.handle.close()
+            self.handle = None
+
+    def read(self, offset, length):
+        self.fsops.read_file_cnt += 1
+        #print(f"Read {self}  FH: {self.handle}")
+        self.handle.seek(offset)
+        return self.handle.read(length)
+
+    def get_size(self):
+        self.fsops.get_size_file_cnt += 1
+        #print(f"Size {self}  FH: {self.handle}")
+        self.handle.seek(0, 2)
+        return self.handle.tell()
+
+class AutoorthoOperations(BaseFileSystemOperations):
+    open_tile_cache_cnt = 0
+    open_tile_direct_cnt = 0
+    open_file_cnt = 0
+    read_tile_cnt = 0
+    read_tile_short_cnt = 0
+    read_file_cnt = 0
+    get_size_file_cnt = 0
+    get_size_tile_cnt = 0
+
     def __init__(self, root, volume_label, tile_cache, read_only=False):
         super().__init__()
         if len(volume_label) > 31:
@@ -156,25 +216,19 @@ class AutoorthoOperations(OperationsShim):
         self.read_only = read_only
         self.root = root
         self._root_path = PureWindowsPath("/")
-        self._root_obj = FolderObj(
-            self._root_path,
-            FILE_ATTRIBUTE.FILE_ATTRIBUTE_DIRECTORY,
-            SecurityDescriptor.from_string("O:BAG:BAD:P(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)(A;OICI;FA;;;WD)"),
-            #SecurityDescriptor.from_string("O:BAG:BAD:P(A;;FA;;;SY)(A;;FA;;;BA)(A;;FA;;;WD)"),
-        )
-        self._entries = {self._root_path: self._root_obj}
+        self.root_security_descr = SecurityDescriptor.from_string("O:BAG:BAD:P(A;;FA;;;SY)(A;;FA;;;BA)(A;;FA;;;WD)")
+
         self._thread_lock = threading.RLock()
         self.dds_re = re.compile(".*\\\(\d+)[-_](\d+)[-_]((?!ZL)\S*)(\d{2}).dds")
         self.tc = tile_cache
+        self.cache_dir = CFG.paths.cache_dir
 
         # Do lots of locking
-        #self.biglock = True
         self.biglock = False
-
-        self.startup = True
 
     # Winfsp operations
 
+    @cache
     def get_volume_info(self):
         return self._volume_info
 
@@ -184,16 +238,10 @@ class AutoorthoOperations(OperationsShim):
 
     #@operation
     def get_security_by_name(self, file_name):
-        file_name = PureWindowsPath(file_name)
         #print(f"GET_SECURITY_BY_NAME: {file_name}")
-
-        full_path = self._full_path(str(file_name))
-       
-        if os.path.isdir(full_path):
-            file_obj = self.add_obj(file_name, self._root_path, True)
-        else:
-            file_obj = self.add_obj(file_name, self._root_path, False)
-
+        file_name = PureWindowsPath(file_name)
+        file_obj = FileObj(file_name, FILE_ATTRIBUTE.FILE_ATTRIBUTE_ARCHIVE,
+                               self.root_security_descr)
         return (
             file_obj.attributes,
             file_obj.security_descriptor.handle,
@@ -201,187 +249,55 @@ class AutoorthoOperations(OperationsShim):
         )
 
     #@operation
-    @lru_cache(maxsize=4096)
-    def add_obj(self, file_name, parent, isdir):
-        file_name = PureWindowsPath(file_name)
-
-        # `granted_access` is already handle by winfsp
-        # `allocation_size` useless for us
-
-        if isdir:
-            file_attributes = FILE_ATTRIBUTE.FILE_ATTRIBUTE_DIRECTORY
-            security_descriptor = self._root_obj.security_descriptor
-            file_obj = FolderObj(
-                file_name, file_attributes, security_descriptor
-            )
-        else:
-            file_attributes = FILE_ATTRIBUTE.FILE_ATTRIBUTE_ARCHIVE
-            security_descriptor = self._root_obj.security_descriptor
-            file_obj = FileObj(
-                file_name, file_attributes, security_descriptor
-            )
-
-        return file_obj
-        
-
-    #@operation
-    #@lru_cache
     @cache
     def get_security(self, file_context):
+        #print(file_context.file_obj.security_descriptor)
         return file_context.file_obj.security_descriptor
 
     #@operation
     def open(self, file_name, create_options, granted_access):
         #print(f"OPEN: {file_name} {create_options} {granted_access}")
         file_name = PureWindowsPath(file_name)
-        # Retrieve file
 
         path = str(file_name)
-        
-        h = -1
+
         m = self.dds_re.match(path)
         if m:
-            if self.startup:
-                # First matched file
-                log.info("First matched DDS file detected.  Start flight tracker.")
-                flighttrack.ft.start()
-                self.startup = False
-
             #print(f"MATCH! {path}")
             row, col, maptype, zoom = m.groups()
             row = int(row)
             col = int(col)
             zoom = int(zoom)
-            #print(f"OPEN: DDS file {path}, offset {offset}, length {length} (%s) " % str(m.groups()))
-            file_obj = self.add_obj(path, self._root_path, False)
-            tile = self.tc._open_tile(row, col, maptype, zoom) 
-            file_obj.tile_id = (row, col, maptype, zoom)
+            file_obj = FileObj(file_name, FILE_ATTRIBUTE.FILE_ATTRIBUTE_ARCHIVE,
+                               self.root_security_descr)
+            return OpenedTileObj(file_obj, row, col, maptype, zoom, self)
+
+        full_path = self._full_path(path)
+        exists = os.path.exists(full_path)
+
+        if not exists:
+             raise NTStatusObjectNameNotFound()
         else:
-            full_path = self._full_path(path)
-            if os.path.isdir(full_path):
-                file_obj = self.add_obj(path, self._root_path, True)
-            elif os.path.exists(full_path):
-                file_obj = self.add_obj(path, self._root_path, False)
-                h = open(full_path, "rb")
-            else:
-                raise NTStatusObjectNameNotFound()
-        return OpenedObj(file_obj, h)
+            #print(f"OPEN: {file_name} {full_path}")
+            #file_obj = self.add_obj(path, self._root_path, False)
+            file_obj = FileObj(file_name, FILE_ATTRIBUTE.FILE_ATTRIBUTE_ARCHIVE,
+                               self.root_security_descr)
+            self.open_file_cnt += 1
+            return OpenedFileObj(file_obj, open(full_path, "rb"), self)
+
+        # what now? the directory stuff is currently unsupported
+        return None
 
     #@operation
     def close(self, file_context):
         #print(f"CLOSE: {file_context}")
-        path = str(file_context.file_obj.path)
-        m = self.dds_re.match(path)
-        if m:
-            self.tc._close_tile(*file_context.file_obj.tile_id)
-        else:
-            fh = file_context.handle
-            if fh != -1:
-                #print(f"Closing {file_context}.  FH: {fh}")
-                #os.close(fh)
-                fh.close()
-                file_context.handle = None
+        file_context.close()
 
     #@operation
-    #@lru_cache(maxsize=4096)
-    @cache
     def get_file_info(self, file_context):
         #print(f"GET_FILE_INFO: {file_context}")
-        path = str(file_context.file_obj.path)
-        #{'file_attributes': 32, 'allocation_size': 0, 'file_size': 0, 'creation_time': 133091265506258958, 'last_access_time': 133091265506258958, 'last_write_time': 133091265506258958, 'change_time': 133091265506258958, 'index_number': 0}
-        #os.stat_result(st_mode=33206, st_ino=562949953931301, st_dev=1421433975, st_nlink=1, st_uid=0, st_gid=0, st_size=832, st_atime=1664639212, st_mtime=1653275838, st_ctime=1653275838)
-
-        m = self.dds_re.match(path)
-        if m:
-            #print(f"MATCH: Set file size")
-            file_context.file_obj.file_size = 22369744
-        else:
-            full_path = self._full_path(path)
-            if os.path.isfile(full_path):
-                st = os.lstat(full_path)
-                file_context.file_obj.file_size = st.st_size
+        file_context.file_obj.file_size = file_context.get_size()
         return file_context.file_obj.get_file_info()
-
-    #@lru_cache
-    @cache
-    def listlocal(self, path):
-        return os.listdir(path)
-
-    #@operation
-    @lru_cache
-    def read_directory(self, file_context, marker, buffer_len):
-        print(f"READ_DIRECTORY {file_context} {marker}")
-        entries = []
-        file_obj = file_context.file_obj
-
-        # Not a directory
-        if isinstance(file_obj, FileObj):
-            raise NTStatusNotADirectory()
-
-        path = str(file_obj.path)
-
-        full_path = self._full_path(path)
-        #print(f"READDIR: {path}")
-
-        #entries = []
-        dirents = ['.', '..']
-        if os.path.isdir(full_path):
-            #dirents.extend(os.listdir(full_path))
-            dirents.extend(self.listlocal(full_path))
-
-        if marker:
-            #print(f"MARKER! {marker} {buffer_len}")
-            marker_idx = dirents.index(marker)
-            dirents = dirents[marker_idx + 1 : marker_idx + 1024]
-            #print(f"DIRENTS LEN: {len(dirents)}")
-
-        #for r in dirents[0:1024]:
-        for r in dirents:
-            #print(r)
-            tpath = os.path.join(path, r)
-            if os.path.isdir(os.path.join(full_path, r)):
-                obj = self.add_obj(tpath, self._root_path, True)
-                tobj = {"file_name": r, **obj.get_file_info()}
-            else:
-                st = os.lstat(os.path.join(full_path, r))
-                obj = self.add_obj(tpath, self._root_path, False)
-                obj.file_size = st.st_size
-                tobj = {"file_name": r, **obj.get_file_info()}
-
-            #print(tobj)
-            #entries.append(tobj)
-            yield tobj
-
-        return
-
-        print(f"NUM ENTRIES: {len(entries)}")
-        entries = sorted(entries, key=lambda x: x["file_name"])
-        for e in entries:
-            yield e
-        return
-
-        return entries
-
-        # No filtering to apply
-        if marker is None:
-            print(f"READ_DIR: {entries}")
-            return entries
-
-        # Filter out all results before the marker
-        for i, entry in enumerate(entries):
-            if entry["file_name"] == marker:
-                print("READ_DIR RETURNING ....")
-                #print(entries[i + 1 :])
-                return entries[i + 1 :]
-        #return
-    
-
-    #@operation
-    @lru_cache
-    def get_dir_info_by_name(self, file_context, file_name):
-        #print(f"GET DIR INFO BY NAME: {file_context} {file_name}")
-        tpath = os.path.join(file_context.file_obj.path, file_name)
-        obj = self.add_obj(tpath, self._root_path, True)
 
     def _full_path(self, partial):
         #print(f"_FULL_PATH: {partial}")
@@ -393,26 +309,7 @@ class AutoorthoOperations(OperationsShim):
     #@operation
     def read(self, file_context, offset, length):
         #print(f"READ: P:{file_context.file_obj.path} O:{offset} L:{length}")
-        data = None
-
-        path = str(file_context.file_obj.path)
-        m = self.dds_re.match(path)
-        if m:
-            #print(f"READ MATCH: {path}")
-            #data = file_context.file_obj.tile.read_dds_bytes(offset, length)
-            #row, col, maptype, zoom = file_context.file_obj.tile_id.split("_")
-            row, col, maptype, zoom = file_context.file_obj.tile_id
-            tile = self.tc._get_tile(row, col, maptype, zoom)
-            data = tile.read_dds_bytes(offset, length)
-            #print(f"READ: {len(data)} bytes")
-        
-        if not data:
-            fh = file_context.handle
-            fh.seek(offset)
-            data = fh.read(length)
-        #print(f"LEN DATA: {len(data)}")
-        return data
-        #return file_context.file_obj.read(offset, length)
+        return file_context.read(offset, length)
 
     #@operation
     def cleanup(self, file_context, file_name, flags) -> None:
@@ -424,19 +321,28 @@ class AutoorthoOperations(OperationsShim):
         pass
 
     def show_stats(self):
+        print("Tile:")
+        print(f" open_cache\t{self.open_tile_cache_cnt}")
+        print(f" open_direct\t{self.open_tile_direct_cnt}")
+        print(f" read\t\t{self.read_tile_cnt}")
+        print(f" read_short\t{self.read_tile_short_cnt}")
+        print(f" get_size\t{self.get_size_tile_cnt}\n")
+        print("File:")
+        print(f" open\t\t{self.open_file_cnt}")
+        print(f" read\t\t{self.read_file_cnt}")
+        print(f" get_size\t{self.get_size_file_cnt}")
+
         method_list = [method for method in dir(AutoorthoOperations) if
                 method.startswith('_') is False]
 
-        self.tc.show_stats()
+        #self.tc.show_stats()
         for m_name in method_list:
             m = getattr(self, m_name)
             if hasattr(m, 'cache_info'):
                 print(f"{m_name}: {m.cache_info()}")
 
-
 def create_file_system(
-    root, mountpoint, label="autoortho", prefix="", verbose=True, debug=False, testing=False
-):
+    root, mountpoint, label="autoortho", prefix="", verbose=True, debug=False, testing=False):
     if debug:
         enable_debug_log()
 
@@ -449,7 +355,8 @@ def create_file_system(
     mountpoint = Path(mountpoint)
     is_drive = mountpoint.parent == mountpoint
     reject_irp_prior_to_transact0 = not is_drive and not testing
-    tc = getortho.TileCacher(".cache") 
+    tc = getortho.TileCacher(".cache")
+
     operations = AutoorthoOperations(str(root), label, tc)
     fs = FileSystem(
         str(mountpoint),
@@ -462,7 +369,7 @@ def create_file_system(
         case_sensitive_search=1,
         case_preserved_names=1,
         unicode_on_disk=1,
-        persistent_acls=0,
+        persistent_acls=1,
         #post_cleanup_when_modified_only=1,
         um_file_context_is_user_context2=1,
         flush_and_purge_on_cleanup=1,
@@ -477,7 +384,7 @@ def create_file_system(
 
 
 def main(root, mountpoint, label="autoorotho", prefix="", verbose=False, debug=False):
-    #debug=True
+    debug=False
     fs = create_file_system(root, mountpoint, label, prefix, verbose, debug)
     try:
         print("Starting FS")
@@ -494,7 +401,6 @@ def main(root, mountpoint, label="autoorotho", prefix="", verbose=False, debug=F
         print("Stopping FS")
         fs.stop()
         print("FS stopped")
-
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()

--- a/autoortho/read_dds_header.py
+++ b/autoortho/read_dds_header.py
@@ -1,0 +1,43 @@
+import sys
+from ctypes import *
+
+class DDS(Structure):
+    _fields_ = [
+        ('magic', c_char * 4),
+        ('size', c_uint32),
+        ('flags', c_uint32),
+        ('height', c_uint32),
+        ('width', c_uint32),
+        ('pitchOrLinearSize', c_uint32),
+        ('depth', c_uint32),
+        ('mipMapCount', c_uint32),
+        ('reserved1', c_char * 44),
+        ('pfSize', c_uint32),
+        ('pfFlags', c_uint32),
+        ('fourCC', c_char * 4),
+        ('rgbBitCount', c_uint32),
+        ('rBitMask', c_uint32),
+        ('gBitMask', c_uint32),
+        ('bBitMask', c_uint32),
+        ('aBitMask', c_uint32),
+        ('caps', c_uint32),
+        ('caps2', c_uint32),
+        ('reservedCaps', c_uint32 * 2),
+        ('reserved2', c_uint32)
+    ]
+
+    def read(self, fn):
+        fh = open(fn, "rb")
+        #len = fh.readinto(self)
+        print(len)
+ 
+        print(f"size:\t{self.size}")
+        print(f"height:\t{self.height}")
+        print(f"width:\t{self.width}")
+        print(f"pitchOrLinearSize:\t{self.pitchOrLinearSize}")
+        print(f"fourCC:\t{self.fourCC}")
+        print(f"mipMapCount:\t{self.mipMapCount}")
+        print(f"depth:\t{self.depth}")
+        
+dds = DDS()
+dds.read(sys.argv[1])

--- a/autoortho/test_winfsp.py
+++ b/autoortho/test_winfsp.py
@@ -1,0 +1,20 @@
+import os
+
+dir = "E:\X-Plane-12\Custom Scenery\z_autoortho"
+
+# direct real file
+print(os.path.exists(dir + "\_textures\water_transition.png"))
+
+#same through winfsp
+print(os.path.exists(dir + "/textures/water_transition.png"))
+
+# 'virtual' DDS
+print(os.path.exists(dir + "/textures/21552_34032_BI16.dds"))
+
+# non existent
+print(os.path.exists(dir + "/textures/bad.dds"))
+
+fh = open(dir + "/textures/21552_34032_BI16.dds", "rb")
+print(fh)
+data = fh.read(1024)
+print(len(data))

--- a/autoortho/test_winfsp.py
+++ b/autoortho/test_winfsp.py
@@ -12,9 +12,14 @@ print(os.path.exists(dir + "/textures/water_transition.png"))
 print(os.path.exists(dir + "/textures/21552_34032_BI16.dds"))
 
 # non existent
-print(os.path.exists(dir + "/textures/bad.dds"))
+#print(os.path.exists(dir + "/textures/bad.dds"))
 
 fh = open(dir + "/textures/21552_34032_BI16.dds", "rb")
+print(fh)
+data = fh.read(1024)
+print(len(data))
+
+fh = open(dir + "/textures/21584_34176_BI16.dds", "rb")
 print(fh)
 data = fh.read(1024)
 print(len(data))


### PR DESCRIPTION
All (most) unnecessary and unused code (e.g. creating directory entries for files we read etc...) is removed. The shim module does not make a difference so I left this out. The function caching only cashed superfluous and now removed functions so I can not see any further improvement with them. They will be moved out in a later step.
I implemented delayed opening of tiles. It looks that now a tile is accessed only once so the tile cache is no longer of value for winfsp as well (hitrate 0).
This optimizations reduced startup time by 10s on my gear.

The true turbo charger is still caching of assembled dds files. I tried to implement this in a minimal invasive way in your code.
I made this a configurable option that currently is only available by editing the config file.