### PR TITLE
Mm0 partial + 2 bug fixes

### DIFF
--- a/autoortho/autoortho_fuse.py
+++ b/autoortho/autoortho_fuse.py
@@ -147,7 +147,7 @@ class AutoOrtho(Operations):
                 'st_mode': 33204,
                 'st_mtime': 1649857251.726115, 
                 'st_nlink': 1, 
-                'st_size': 22369744, 
+                'st_size': 22369776, 
                 'st_blksize': 32768
                 #'st_blksize': 16384
                 #'st_blksize': 8192

--- a/autoortho/autoortho_winfsp.py
+++ b/autoortho/autoortho_winfsp.py
@@ -294,7 +294,7 @@ class AutoorthoOperations(OperationsShim):
         m = self.dds_re.match(path)
         if m:
             #print(f"MATCH: Set file size")
-            file_context.file_obj.file_size = 22369744
+            file_context.file_obj.file_size = 22369776
         else:
             full_path = self._full_path(path)
             if os.path.isfile(full_path):

--- a/autoortho/getortho.py
+++ b/autoortho/getortho.py
@@ -529,7 +529,6 @@ class Tile(object):
 
 
     def get_bytes(self, offset, length):
-
         mipmap = self.find_mipmap_pos(offset)
         log.debug(f"Get_bytes for mipmap {mipmap} ...")
         if mipmap > 4:
@@ -570,8 +569,12 @@ class Tile(object):
 
         self.ready.clear()
         #log.info(new_im.size)
+        mm0_partial = 0
+        if mipmap == 0 and offset == 0 and 128 <= length and length <= 64000:
+            mm0_partial = length - 128
+
         try:
-            self.dds.gen_mipmaps(new_im, mipmap, 1)
+            self.dds.gen_mipmaps(new_im, mipmap, 1, mm0_partial = mm0_partial)
         finally:
             new_im.close()
 
@@ -586,7 +589,7 @@ class Tile(object):
         
         mm_idx = self.find_mipmap_pos(offset)
         mipmap = self.dds.mipmap_list[mm_idx]
-        
+
         if offset == 0:
             # If offset = 0, read the header
             log.debug("TILE: Read header")

--- a/autoortho/test_pydds.py
+++ b/autoortho/test_pydds.py
@@ -28,7 +28,7 @@ def test_dds_conv(tmpdir):
     outpath = os.path.join(tmpdir, 'test_tile.dds')
     pydds.to_dds(timg, outpath)
     
-    expectedbytes = 22369744
+    expectedbytes = 22369776
     actualbytes = os.path.getsize(outpath)
 
     assert expectedbytes == actualbytes
@@ -43,7 +43,7 @@ def test_empty_dds(tmpdir):
     dds = pydds.DDS(4096, 4096)
     dds.write(outpath)
     
-    expectedbytes = 22369744
+    expectedbytes = 22369776
     actualbytes = os.path.getsize(outpath)
     assert expectedbytes == actualbytes
 
@@ -112,7 +112,7 @@ def test_read_mid(tmpdir):
     assert data2[:128] == b'\x88'*128
 
     dds.write(outpath)
-    expectedbytes = 22369744
+    expectedbytes = 22369776
     actualbytes = os.path.getsize(outpath)
     assert expectedbytes == actualbytes
 


### PR DESCRIPTION
- pitchOrLinearSize was computed wrongly and some dds viewers refused to open the generated files
- mm0_partial optimization I mentioned in a separate email
- XP >= 12.04b3 insists on getting 13 mipmaps i.e. down to 1x1