### PR TITLE
Enable FUSE mode for Windows using Dokan

### DIFF
--- a/autoortho/aoconfig.py
+++ b/autoortho/aoconfig.py
@@ -393,6 +393,8 @@ compressor = ISPC
 [fuse]
 # Enable or disable multi-threading when using FUSE
 threading = True
+# Enable Windows to use FUSE mode
+winfuse = False
 
 [winfsp]
 

--- a/autoortho/aostats.py
+++ b/autoortho/aostats.py
@@ -13,7 +13,7 @@ class AOStats(object):
         #global STATS
         #STATS=self.
         self.running = False
-        self._t = threading.Thread(target=self.show)
+        self._t = threading.Thread(daemon=True, target=self.show)
 
     def start(self):
         log.info("Starting stats thread")

--- a/autoortho/autoortho.py
+++ b/autoortho/autoortho.py
@@ -76,12 +76,17 @@ def main():
         log.info("Running in Windows WinFSP mode.")
         import autoortho_winfsp
         autoortho_winfsp.main(root, mountpoint)
-    elif winfuse == True:
+    elif platform.system() == 'Windows' and winfuse:
         log.info("Logging in FUSE mode.")
         import autoortho_fuse
         root = os.path.expanduser(root)
         mountpoint = os.path.expanduser(mountpoint)
         nothreads=False
+        #if not os.path.exists(mountpoint):
+        #    os.makedirs(mountpoint)
+        #if not os.path.isdir(mountpoint):
+        #    log.error(f"WARNING: {mountpoint} is not a directory.  Exiting.")
+        #    sys.exit(1)
 
         if CFG.fuse.threading:
             log.info("Running in multi-threaded mode.")

--- a/autoortho/autoortho.py
+++ b/autoortho/autoortho.py
@@ -71,8 +71,8 @@ def main():
     )
     ftrack.start()
 
-    winfuse = False
-    if platform.system() == 'Windows':
+    winfuse = True
+    if platform.system() == 'Windows' and not winfuse:
         log.info("Running in Windows WinFSP mode.")
         import autoortho_winfsp
         autoortho_winfsp.main(root, mountpoint)

--- a/autoortho/autoortho.py
+++ b/autoortho/autoortho.py
@@ -72,22 +72,21 @@ def main():
     )
     ftrack.start()
 
-    winfuse = True
+    winfuse = CFG.fuse.winfuse
     if platform.system() == 'Windows' and not winfuse:
         log.info("Running in Windows WinFSP mode.")
         import autoortho_winfsp
         autoortho_winfsp.main(root, mountpoint)
     elif platform.system() == 'Windows' and winfuse:
-        log.info("Logging in FUSE mode.")
+        log.info("Running in Windows FUSE mode.")
         import autoortho_fuse
         root = os.path.expanduser(root)
         mountpoint = os.path.expanduser(mountpoint)
         nothreads=False
-        #if not os.path.exists(mountpoint):
-        #    os.makedirs(mountpoint)
-        #if not os.path.isdir(mountpoint):
-        #    log.error(f"WARNING: {mountpoint} is not a directory.  Exiting.")
-        #    sys.exit(1)
+
+        if not os.path.lexists(mountpoint):
+            log.info(f"Creating mountpoint: {mountpoint}")
+            os.makedirs(mountpoint)
 
         if CFG.fuse.threading:
             log.info("Running in multi-threaded mode.")
@@ -103,7 +102,7 @@ def main():
                 nothreads
         )
     else:
-        log.info("Logging in FUSE mode.")
+        log.info("Running in FUSE mode.")
         import autoortho_fuse
         root = os.path.expanduser(root)
         mountpoint = os.path.expanduser(mountpoint)

--- a/autoortho/autoortho_fuse.py
+++ b/autoortho/autoortho_fuse.py
@@ -21,7 +21,11 @@ from functools import wraps, lru_cache
 from ctypes.util import find_library
 
 if platform.system() == 'Windows':
-    _libfuse_path = find_library('dokanfuse2.dll')
+    _libfuse_path = find_library('dokanfuse3.dll')
+    if not _libfuse_path:
+        print("Dokan v2 install required for Windows FUSE mode. See: https://github.com/dokan-dev/dokany/releases/latest/download/DokanSetup.exe")
+        input("Press any key to continue")
+        sys.exit(1)
     os.environ['FUSE_LIBRARY_PATH'] = _libfuse_path
 
 from fuse import FUSE, FuseOSError, Operations, fuse_get_context

--- a/autoortho/autoortho_fuse.py
+++ b/autoortho/autoortho_fuse.py
@@ -19,6 +19,7 @@ import flighttrack
 
 from functools import wraps, lru_cache
 
+#os.environ['FUSE_LIBRARY_PATH'] = os.path.join(os.path.dirname(os.path.realpath(__file__)),'lib','windows', 'dokanfuse2.dll')
 from fuse import FUSE, FuseOSError, Operations, fuse_get_context
 #from refuse.high import FUSE, FuseOSError, Operations, fuse_get_context
 
@@ -176,9 +177,9 @@ class AutoOrtho(Operations):
 
         return attrs
 
-    @lru_cache
+    #@lru_cache
     def readdir(self, path, fh):
-        log.debug(f"READDIR: {path}")
+        log.info(f"READDIR: {path}")
 
         if path not in self.path_dict:
             full_path = self._full_path(path)
@@ -229,6 +230,7 @@ class AutoOrtho(Operations):
                     'f_frsize':1024, 
                     'f_namemax':1024
             }
+            stats = {}
             return stats
             # st = os.stat(full_path)
             # return dict((key, getattr(st, key)) for key in ('f_bavail', 'f_bfree',
@@ -311,6 +313,8 @@ class AutoOrtho(Operations):
     #@lru_cache
     def read(self, path, length, offset, fh):
         log.debug(f"READ: {path} {offset} {length} {fh}")
+        if length > 32768:
+            log.info(f"READ: {path} {offset} {length} {fh}")
         data = None
         
         #full_path = self._full_path(path)
@@ -421,7 +425,8 @@ def run(ao, mountpoint, nothreads=False):
         nothreads=nothreads, 
         foreground=True, 
         allow_other=True,
-        auto_cache=True,
+        #auto_cache=True,
+        #max_read=32768,
         #max_read=16384,
         #kernel_cache=True,
         uid=-1,
@@ -429,7 +434,7 @@ def run(ao, mountpoint, nothreads=False):
         #debug=True,
         #mode="0777",
         #umask="777",
-        FileSecurity="O:BAG:BAD:P(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)(A;OICI;FA;;;WD)",
+        #FileSecurity="O:BAG:BAD:P(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)(A;OICI;FA;;;WD)",
         #FileSecurity="D:P(A;;FA;;;OW)",
         #FileSecurity="D:P(A;;0x1200A9;;;WD)",
         #FileSecurity="D:P(A;OICI;FA;;;WD)(A;OICI;FA;;;BU)(A;OICI;FA;;;BA)(A;OICI;FA;;;OW)",

--- a/autoortho/autoortho_fuse.py
+++ b/autoortho/autoortho_fuse.py
@@ -71,8 +71,8 @@ class AutoOrtho(Operations):
 
     fh = 1000
 
-    default_uid = 0
-    default_gid = 0
+    default_uid = -1
+    default_gid = -1
 
     startup = True
 
@@ -133,7 +133,7 @@ class AutoOrtho(Operations):
             log.debug(f"GETATTR: {path}: MATCH!")
             if self.startup:
                 # First matched file
-                log.info("First matched DDS file detected.  Start flight tracker.")
+                log.info(f"First matched DDS file {path} detected.  Start flight tracker.")
                 flighttrack.ft.start()
                 self.startup = False
 
@@ -210,6 +210,7 @@ class AutoOrtho(Operations):
     def mkdir(self, path, mode):
         return os.mkdir(self._full_path(path), mode)
 
+    @lru_cache
     def statfs(self, path):
         log.info(f"STATFS: {path}")
         full_path = self._full_path(path)
@@ -420,14 +421,15 @@ def run(ao, mountpoint, nothreads=False):
         nothreads=nothreads, 
         foreground=True, 
         allow_other=True,
-        #auto_cache=True,
+        auto_cache=True,
         #max_read=16384,
         #kernel_cache=True,
-        #uid=-1,
-        #gid=-1,
+        uid=-1,
+        gid=-1,
         #debug=True,
         #mode="0777",
         #umask="777",
+        FileSecurity="O:BAG:BAD:P(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)(A;OICI;FA;;;WD)",
         #FileSecurity="D:P(A;;FA;;;OW)",
         #FileSecurity="D:P(A;;0x1200A9;;;WD)",
         #FileSecurity="D:P(A;OICI;FA;;;WD)(A;OICI;FA;;;BU)(A;OICI;FA;;;BA)(A;OICI;FA;;;OW)",

--- a/autoortho/autoortho_fuse.py
+++ b/autoortho/autoortho_fuse.py
@@ -21,7 +21,7 @@ from functools import wraps, lru_cache
 from ctypes.util import find_library
 
 if platform.system() == 'Windows':
-    _libfuse_path = find_library('dokanfuse3.dll')
+    _libfuse_path = find_library('dokanfuse2.dll')
     if not _libfuse_path:
         print("Dokan v2 install required for Windows FUSE mode. See: https://github.com/dokan-dev/dokany/releases/latest/download/DokanSetup.exe")
         input("Press any key to continue")

--- a/autoortho/flighttrack.py
+++ b/autoortho/flighttrack.py
@@ -69,7 +69,11 @@ class FlightTracker(object):
                 log.debug("Socket timeout.  Reset.")
                 RequestDataRefs(self.sock)
                 continue
-            
+            except ConnectionResetError: 
+                log.debug("Connection reset.")
+                time.sleep(2)
+                continue
+
             if not self.connected:
                 # We are transitioning states
                 log.info("FT: Flight is starting.")

--- a/autoortho/getortho.py
+++ b/autoortho/getortho.py
@@ -826,8 +826,9 @@ class TileCacher(object):
     def show_stats(self):
         process = psutil.Process(os.getpid())
         cur_mem = process.memory_info().rss
-        log.info(f"TILE CACHE:  MISS: {self.misses}  HIT: {self.hits}")
-        log.info(f"NUM TILES CACHED: {len(self.tiles)}.  TOTAL MEM: {cur_mem//1048576} MB")
+        if self.enable_cache:
+            log.info(f"TILE CACHE:  MISS: {self.misses}  HIT: {self.hits}")
+        log.info(f"NUM OPEN TILES: {len(self.tiles)}.  TOTAL MEM: {cur_mem//1048576} MB")
 
     def clean(self):
         memlimit = pow(2,30) * 2

--- a/autoortho/locustfile.py
+++ b/autoortho/locustfile.py
@@ -67,7 +67,9 @@ class DDSClient():
         #col = (random.randint(0, 256) * 16) + 30000
         row = self.row + 16
         col = self.col + 16
+        
         testfile = os.path.join(self.path, f"{row}_{col}_BI16.dds")
+        #print(testfile)
 
         with open(testfile, "rb") as h:
             header = h.read(128)
@@ -115,7 +117,10 @@ class DDSRead(User):
 
 class DDSUser(DDSRead):
     #path = "./mount"
-    path = "/home/mkubilus/Software/xplane/autoortho/Custom Scenery/z_autoortho/textures"
+    #path = "/home/mkubilus/Software/xplane/autoortho/Custom Scenery/z_autoortho/textures"
+    print(CFG.paths)
+    print(CFG.paths.mountpoint)
+    path = os.path.join(CFG.paths.mountpoint, 'textures')
 
     @task(1)
     def read_mm0(self):

--- a/autoortho/pydds.py
+++ b/autoortho/pydds.py
@@ -284,10 +284,10 @@ class DDS(Structure):
                         # we *must* make sure the full size is available.
                         # 
                         #log.warning(f"PYDDS: No buffer for {mipmap.idx}, Attempt to fill {remaining_mipmap_len} bytes")
-                        log.warning(f"PYDDS: No buffer for {mipmap.idx}!")
+                        log.debug(f"PYDDS: No buffer for {mipmap.idx}!")
                         #data = b''
                         data = b'\x88' * remaining_mipmap_len
-                        log.warning(f"PYDDS: adding to outdata {remaining_mipmap_len} bytes for {mipmap.idx}.")
+                        log.debug(f"PYDDS: adding to outdata {remaining_mipmap_len} bytes for {mipmap.idx}.")
                     else:    
                         # Mipmap is retrieved
                         mipmap.databuffer.seek(mipmap_pos)


### PR DESCRIPTION
Using Dokan we can use the FUSE path, removing the need for a separate path for WinFSP.  This appears to work a bit better, in most modes.