### PR TITLE
Convert after reduce

### DIFF
--- a/autoortho/flighttrack.py
+++ b/autoortho/flighttrack.py
@@ -68,10 +68,15 @@ class FlightTracker(object):
                 self.connected = False
                 log.debug("Socket timeout.  Reset.")
                 RequestDataRefs(self.sock)
+                time.sleep(2)
                 continue
             except ConnectionResetError: 
                 log.debug("Connection reset.")
                 time.sleep(2)
+                continue
+            except Exception as err:
+                log.debug(f"Some other error {err}")
+                time.sleep(5)
                 continue
 
             if not self.connected:

--- a/autoortho/getortho.py
+++ b/autoortho/getortho.py
@@ -469,7 +469,7 @@ class Tile(object):
 
         outfile = os.path.join(self.cache_dir, f"{self.row}_{self.col}_{self.maptype}_{self.zoom}_{zoom}.dds")
 
-        new_im = Image.new('RGBA', (256*width,256*height), (250,250,250))
+        new_im = Image.new('RGB', (256*width,256*height), (250,250,250))
         try:
             for chunk in self.chunks[zoom]:
                 ret = chunk.ready.wait()
@@ -482,7 +482,7 @@ class Tile(object):
                 #end_y = int(start_y + chunk.height)
 
                 new_im.paste(
-                    Image.open(BytesIO(chunk.data)).convert("RGBA"),
+                    Image.open(BytesIO(chunk.data)),
                     (
                         start_x,
                         start_y
@@ -611,7 +611,8 @@ class Tile(object):
             log.debug("READ_DDS_BYTES: Read header")
             self.get_bytes(0, length)
         #elif offset < 32768:
-        elif offset < 131072:
+        elif offset < 65536:
+        #elif offset < 131072:
         #elif offset < 262144:
         #elif offset < 1048576:
             # How far into mipmap 0 do we go before just getting the whole thing
@@ -707,7 +708,7 @@ class Tile(object):
         #outfile = os.path.join(self.cache_dir, f"{self.row}_{self.col}_{self.maptype}_{self.zoom}_{self.zoom}.dds")
         #new_im = Image.new('RGBA', (256*width,256*height), (250,250,250))
         log.debug(f"GET_IMG: Create new image: Zoom: {self.zoom} | {(256*width, 256*height)}")
-        new_im = Image.new('RGBA', (256*width,256*height), (0,0,0))
+        new_im = Image.new('RGB', (256*width,256*height), (0,0,0))
         #log.info(f"NUM CHUNKS: {len(chunks)}")
         for chunk in chunks:
             ret = chunk.ready.wait()
@@ -718,7 +719,7 @@ class Tile(object):
             start_y = int((chunk.height) * (chunk.row - row))
 
             new_im.paste(
-                Image.open(BytesIO(chunk.data)).convert("RGBA"),
+                Image.open(BytesIO(chunk.data)),
                 (
                     start_x,
                     start_y
@@ -912,7 +913,7 @@ class TileCacher(object):
                 continue
 
             while len(self.tiles) >= self.cache_tile_lim and cur_mem > self.cache_mem_lim:
-                log.info("Hit cache limit.  Remove oldest 20")
+                log.debug("Hit cache limit.  Remove oldest 20")
                 with self.tc_lock:
                     for i in list(self.tiles.keys())[:20]:
                         t = self.tiles.get(i)

--- a/autoortho/perftest.py
+++ b/autoortho/perftest.py
@@ -11,7 +11,8 @@ import subprocess
 TESTIMG = os.path.join("testfiles", "test_tile2.jpg")
 TESTIMG_small = os.path.join("testfiles", "test_tile_small.jpg")
 testimg = Image.open(TESTIMG)
-testimg_rgba = testimg.convert('RGBA')
+#testimg_rgba = testimg.convert('RGBA')
+testimg_rgba = testimg
 smallimg = Image.open(TESTIMG_small)
 #wand_img = wand_image.Image(filename=TESTIMG)
 #testimg.convert('RGBA')

--- a/autoortho/profile_pydds.py
+++ b/autoortho/profile_pydds.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+
+import os
+import cProfile
+from PIL import Image
+
+import pydds
+
+def testgen(img):
+    for i in range(20):
+        width, height = img.size
+        dds = pydds.DDS(width, height)
+        dds.gen_mipmaps(img)
+
+def main():
+    
+    #inimg = sys.argv[1]
+    #outimg = sys.argv[2]
+    
+    
+    TESTIMG = os.path.join("testfiles", "test_tile2.jpg")
+    img = Image.open(TESTIMG)
+    #img = img.convert("RGBA")
+    #width, height = img.size
+    #dds = pydds.DDS(width, height)
+    profile = cProfile.Profile()
+    #profile.runcall(dds.gen_mipmaps, img, 0, 1)
+    profile.runcall(testgen, img)
+    profile.print_stats()
+    #dds.gen_mipmaps(img)
+
+if __name__ == "__main__":
+    #cProfile.run("main()")
+    main()

--- a/autoortho/pydds.py
+++ b/autoortho/pydds.py
@@ -139,7 +139,7 @@ class DDS(Structure):
     ]
 
 
-    def __init__(self, width, height, ispc=True, dxt_format="BC3"):
+    def __init__(self, width, height, ispc=True, dxt_format="BC1"):
         self.magic = b"DDS "  
         self.size = 124
         self.flags = DDSD_CAPS | DDSD_HEIGHT | DDSD_WIDTH | DDSD_PIXELFORMAT | DDSD_MIPMAPCOUNT | DDSD_LINEARSIZE
@@ -453,6 +453,9 @@ class DDS(Structure):
 
                     timg = img.reduce(reduction_ratio)
 
+                    if timg.mode == "RGB":
+                        timg = timg.convert("RGBA")
+
                     imgdata = timg.tobytes()
                     width, height = timg.size
                     log.debug(f"MIPMAP: {mipmap} SIZE: {timg.size}")
@@ -491,8 +494,8 @@ class DDS(Structure):
 
 
 def to_dds(img, outpath):
-    if img.mode == "RGB":
-        img = img.convert("RGBA")
+    #if img.mode == "RGB":
+    #    img = img.convert("RGBA")
     width, height = img.size
 
     dds = DDS(width, height)


### PR DESCRIPTION
Though it's more efficient in some ways to go this route, since RGBA conversion is shifted to tile creation vs chunk creation time, there is more time in the lock, which may slow things down in some instances.

From a perf test perspective this is faster, and is more efficient.  But may need more work.