### PR TITLE
Re-enable padding if mipmap 0 could not be retrieved

### DIFF
--- a/autoortho/pydds.py
+++ b/autoortho/pydds.py
@@ -324,9 +324,9 @@ class DDS(Structure):
                     ret_len = remaining_mipmap_len - len(data)
                     if ret_len != 0:
                         log.error(f"PYDDS: ERROR! Didn't retrieve full length of mipmap for {mipmap.idx}!")
-                        #log.error(f"PYDDS: Didn't retrieve full length.  Fill empty bytes {ret_len}")
+                        log.error(f"PYDDS: Didn't retrieve full length.  Fill empty bytes {ret_len}")
                         # Pretty sure this causes visual corruption
-                        #data += b'\x88' * ret_len
+                        data += b'\x88' * ret_len
 
                     outdata += data
 


### PR DESCRIPTION
I have had crashes with X-Plane 12.05b3.

autoortho logs this:
```
ERROR:pydds:PYDDS: ERROR! Didn't retrieve full length of mipmap for 0!
```

Followed immediately by X-Plane outputting this:

```
ERROR elf_dynamic_array_reader.h:64] tag not found
...
ERROR process_memory_range.cc:75] read out of range
WARNING thread_snapshot_linux.cc:112] Unknown scheduling policy 1073741826
...
ERROR process_memory_range.cc:75] read out of range
ERROR process_memory_range.cc:75] read out of range
WARNING image_annotation_reader.cc:92] duplicate simple annotation gpu_api opengl
WARNING image_annotation_reader.cc:92] duplicate simple annotation ogl_vend 530.41.3
WARNING image_annotation_reader.cc:92] duplicate simple annotation ogl_rend NVIDIA GeForce RTX 3060
WARNING image_annotation_reader.cc:92] duplicate simple annotation art_controls 1
```
and dying.

Attaching a debugger or inspecting the core dump shows this X-Plane backtrace:
```
Program terminated with signal SIGBUS, Bus error.

#0  0x00007f834be847a0 in  () at /usr/lib/libc.so.6
#1  0x0000000000f43e65 in TEX_obj::load_texture_data(TEX_obj_load_data const&, std::__1::function<void (TEX_obj_load_result const&)>&&) ()
#2  0x0000000000f41570 in TEX_obj::do_load(unsigned int, bool, UTL_continuable*) ()
#3  0x0000000000f5482e in lambda_wrapper<TEX_obj::queue_load_async(bool, UTL_continuable*)::$_1>::resume(resume_base*) ()
#4  0x0000000000cf0d10 in UTL_threadpool::thread_func(void*) ()
#5  0x0000000000539d87 in THREAD_launch(void*) ()
```

This patch just re-enables what you already did there: padding the data to the expected length.

In the cases I had with the patch where this code path gets activated the output looks like this:
```
ERROR! Didn't retrieve full length of mipmap for 0!
Didn't retrieve full length.  Fill empty bytes 65664
``` 
Then X-Plane reads the texture and continues. I have not seen visual artifacts yet.