### PR TITLE
Add binary artifact to release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,9 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: winbin
-        path: autoortho_win.exe
+        path: |
+          autoortho_win.exe
+          autoortho_win.zip
 
     - name: Release
       uses: softprops/action-gh-release@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,12 @@ jobs:
         make autoortho_lin.bin
         zip autoortho_lin.zip autoortho_lin.bin
 
+    - name: Save artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: linbin
+        path: autoortho_lin.bin
+
     - name: Release
       uses: softprops/action-gh-release@v1
       with:
@@ -49,6 +55,12 @@ jobs:
       run: |
         make autoortho_win.exe
         7z a autoortho_win.zip autoortho_win.exe
+
+    - name: Save artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: winbin
+        path: autoortho_win.exe
 
     - name: Release
       uses: softprops/action-gh-release@v1


### PR DESCRIPTION
This brings release.yml in line with build.yml.

It allows wary people to verify that the release artifact has been built completely in a Github runner from the totally transparent sources and with the public build steps.