### PR TITLE
use refuse in test

### DIFF
--- a/autoortho/test_autoortho.py
+++ b/autoortho/test_autoortho.py
@@ -14,7 +14,7 @@ import random
 import string
 import tempfile
 
-from fuse import fuse_exit
+from refuse.high import fuse_exit
 
 import autoortho_fuse
 import aostats


### PR DESCRIPTION
This just changes the import to `refuse` to enable the test_autoortho.py test again.

The tests run fine apart from some flakiness in the GUI test in `test_aoconfig.py`.

```
cd autoortho && pytest .
```