### PR TITLE
adjust image referenced in aoimage test

### DIFF
--- a/autoortho/aoimage/main.c
+++ b/autoortho/aoimage/main.c
@@ -10,7 +10,7 @@ int main(void) {
     
     aoimage_t img;
 
-    if(!aoimage_read_jpg("../testfiles/test_tile.jpg", &img)) {
+    if(!aoimage_read_jpg("../testfiles/test_tile2.jpg", &img)) {
         printf("Error in loading the image\n");
         exit(1);
     }


### PR DESCRIPTION
The ./main is currently not used in the tests but is still useful to test the pure .c side of it.