### PR TITLE
Update WinFSP section to work on Windows 11

### DIFF
--- a/autoortho/autoortho.py
+++ b/autoortho/autoortho.py
@@ -49,6 +49,7 @@ def run(root, mountpoint, threading=True):
             )
         elif systemtype == "winfsp-FUSE":
             log.info("Running in Windows FUSE mode with WinFSP.")
+            os.environ['FUSE_LIBRARY_PATH'] = libpath
             root = os.path.expanduser(root)
             mountpoint = os.path.expanduser(mountpoint)
             winsetup.setup_winfsp_mount(mountpoint) 


### PR DESCRIPTION
Added os.environ['FUSE_LIBRARY_PATH'] = libpath to the WinFSP section of AutoOrtho.py to enable using WinFSP while Dokan is broken on Windows 11