### PR TITLE
Order cache by tile names

### DIFF
--- a/autoortho/getortho.py
+++ b/autoortho/getortho.py
@@ -193,17 +193,32 @@ class Chunk(object):
     serverlist=['a','b','c','d']
 
     def __init__(self, col, row, maptype, zoom, priority=0, cache_dir='.cache'):
+        # Slippy -> lat/lon
+        def num2deg(col, row, zoom):
+            n = 1 << zoom
+            lonDeg = col / n * 360.0 - 180.0
+            latRad = math.atan(math.sinh(math.pi * (1 - 2 * row / n)))
+            latDeg = math.degrees(latRad)
+            return latDeg, lonDeg
+
         self.col = col
         self.row = row
         self.zoom = zoom
         self.maptype = maptype
-        self.cache_dir = cache_dir
-        
+
+        latDeg, lonDeg = num2deg(self.col, self.row, self.zoom)
+        tile = '{:+03d}{:+04d}'.format(math.floor(latDeg), math.floor(lonDeg))
+
+        self.cache_dir = os.path.join(cache_dir, tile)
+
+        log.info(f"Slippy {self.col} {self.row} {self.zoom} => Cache {self.cache_dir}")
+
         # Hack override maptype
         #self.maptype = "BI"
 
         if not priority:
             self.priority = zoom
+
         self.chunk_id = f"{col}_{row}_{zoom}_{maptype}"
         self.ready = threading.Event()
         self.ready.clear()
@@ -243,6 +258,10 @@ class Chunk(object):
     def save_cache(self):
         if not self.data:
             return
+
+        if not os.path.isdir(self.cache_dir):
+            log.info(f"Creating cache dir {self.cache_dir}")
+            os.makedirs(self.cache_dir)
 
         with open(self.cache_path, 'wb') as h:
             h.write(self.data)


### PR DESCRIPTION
This changes the cache directory layout to give its contents more semantic information.

It creates sub-directories like `-48+013/` when cache images are saved.

This allows to see which data has been downloaded for a region. It also enables manual pruning of a region if needed without additional tools to deal with the Slippy tile names.

TODO: It does not move existing files into the new structure yet.

So that's currently just a proposal for a more obvious cache structure.