### PR TITLE
show download speed with the correct units

### DIFF
--- a/autoortho/downloader.py
+++ b/autoortho/downloader.py
@@ -229,8 +229,8 @@ class Package(object):
         MBps = (total_fetched/1048576) / elapsed
         cur_activity['pcnt_done'] = pcnt_done
         cur_activity['MBps'] = MBps
-        print(f"\r{pcnt_done:.2f}%   {MBps:.2f} MBps", end='')
-        cur_activity['status'] = f"Downloading {self.dl_url}\n{pcnt_done:.2f}%   {MBps:.2f} MBps"
+        print(f"\r{pcnt_done:.2f}%   {MBps:.2f} Mbps", end='')
+        cur_activity['status'] = f"Downloading {self.dl_url}\n{pcnt_done:.2f}%   {MBps:.2f} Mbps"
 
     def check(self):
         log.info(f"Checking {self.name}")


### PR DESCRIPTION
These speeds are in Mega*bits* per second, a capital B signified Mega*bytes* per second. This fixes the discrepancy.