### PR TITLE
Fix 'duplicate' best chunk tile matches

### DIFF
--- a/autoortho/getortho.py
+++ b/autoortho/getortho.py
@@ -799,9 +799,13 @@ class Tile(object):
             col_offset = col % scalefactor
             row_offset = row % scalefactor
 
+            log.debug(f"Col_Offset: {col_offset}, Row_Offset: {row_offset}, Scale_Factor: {scalefactor}")
+
             # Pixel width
             w_p = 256 >> diff
             h_p = 256 >> diff
+
+            log.debug(f"Pixel Size: {w_p}x{h_p}")
 
             # Load image to crop
             img_p = AoImage.load_from_memory(c.data)
@@ -812,11 +816,12 @@ class Tile(object):
 
             # Crop
             crop_img = AoImage.new('RGBA', (w_p, h_p), (0,255,0))
-            img_p.crop(crop_img, (col_offset, row_offset))
+            img_p.crop(crop_img, (col_offset * w_p, row_offset * h_p))
             chunk_img = crop_img.scale(scalefactor)
 
             return chunk_img
 
+        log.debug(f"No best chunk found for {col}x{row}x{zoom}!")
         return False
 
 

--- a/autoortho/getortho.py
+++ b/autoortho/getortho.py
@@ -825,29 +825,6 @@ class Tile(object):
         return False
 
 
-    def _get_best_chunk(self, x, y, mm):
-        for i in range(mm+1, 5):
-            if i in self.imgs:
-                # We have an image already
-                img = self.imgs[i]
-
-                # Difference between requested mm and found image mm level
-                mmdiff = i - mm
-
-                mm4_x = x >> mmdiff
-                mm4_y = y >> mmdiff
-                scalefactor = 1 << mmdiff
-
-                mm_w = 256 >> mmdiff
-                mm_h = 256 >> mmdiff
-
-                log.debug(f"GET_IMG: {self} Crop: {mm4_x}x{mm4_y} w:{mm_w} h:{mm_h}")
-                crop_img = AoImage.new('RGBA', (mm_w, mm_h), (0,255,0))
-                img.crop(crop_img, (mm4_x, mm4_y))
-                chunk_img = crop_img.scale(scalefactor)
-                return chunk_img
-        return False
-
     #@profile
     @locked
     def get_mipmap(self, mipmap=0):

--- a/autoortho/test_getortho.py
+++ b/autoortho/test_getortho.py
@@ -338,3 +338,19 @@ def test_get_best_chunk(tmpdir):
     ret = tile3.get_best_chunk(18408, 26857, 0, 16)
     assert not ret
 
+
+@pytest.mark.parametrize("mm", [4,3,2,1])
+def test_get_best_chunks_all(mm, tmpdir):
+    tile = getortho.Tile(17408, 25856, 'BI', 16, cache_dir=tmpdir)
+    
+    # Verify we get a match
+    tile.get_img(mm)
+
+    for x in range(16):
+        for y in range(16):
+            ret = tile.get_best_chunk(17408+x, 25856+y, 0, 16)
+            assert(ret)
+            ret.write_jpg(os.path.join(tmpdir, f"best_{mm}_{x}_{y}.jpg"))
+
+    #assert True == False
+    


### PR DESCRIPTION
This should resolve the appearance of 'duplicate' tiles when lower res tiles are fetched en-masse.   Really these were slightly shifted tiles that needed to be indexed by the current tile lookup index width.  