### PR TITLE
Changed z_autoortho folder name to ZAutoOrtho

### DIFF
--- a/autoortho/aoconfig.py
+++ b/autoortho/aoconfig.py
@@ -139,7 +139,7 @@ prefer_winfsp = False
 
         self.ao_scenery_path = os.path.join(
                 self.paths.scenery_path,
-                "z_autoortho",
+                "zAutoOrtho",
                 "scenery"
         )
       

--- a/autoortho/downloader.py
+++ b/autoortho/downloader.py
@@ -318,7 +318,7 @@ class Release(object):
         self.url = url
         self.release_dict = release_dict if release_dict else {}
         self.packages = {}
-        self.info_path = os.path.join(self.install_dir, "z_autoortho", f"{self.name}_info.json")
+        self.info_path = os.path.join(self.install_dir, "zAutoOrtho", f"{self.name}_info.json")
         self.ortho_dirs = []
         self.info_ver = "v2"
 
@@ -432,7 +432,7 @@ class Release(object):
                 p.install_dir = f"{self.install_dir}/yAutoOrtho_Overlays"
             elif pkgtype == "z":
                 # Ortho package
-                p.install_dir = f"{self.install_dir}/z_autoortho/scenery/z_ao_{self.id}"
+                p.install_dir = f"{self.install_dir}/zAutoOrtho/scenery/z_ao_{self.id}"
 
 
             p.remote_urls.append(a.get('browser_download_url'))
@@ -513,8 +513,8 @@ class Release(object):
                 shutil.rmtree(o)
 
         legacy_dirs = [
-            os.path.join(self.install_dir, "z_autoortho", "textures"),
-            os.path.join(self.install_dir, "z_autoortho", "_textures")
+            os.path.join(self.install_dir, "zAutoOrtho", "textures"),
+            os.path.join(self.install_dir, "zAutoOrtho", "_textures")
         ]
         for l in legacy_dirs:
             if os.path.exists(l):
@@ -550,7 +550,7 @@ class Region(object):
     def find_existing(self):
         log.info(f"Checking installed releases for {self.region_id}")
         local_rel_info = glob.glob(os.path.join(
-            self.install_dir, "z_autoortho", f"{self.region_id}_info.json"
+            self.install_dir, "zAutoOrtho", f"{self.region_id}_info.json"
         ))
         
         for rel in [ os.path.basename(rel) for rel in local_rel_info ]:

--- a/autoortho/locustfile.py
+++ b/autoortho/locustfile.py
@@ -117,9 +117,9 @@ class DDSRead(User):
 
 class DDSUser(DDSRead):
     #path = "./mount"
-    #path = "/home/mkubilus/Software/xplane/autoortho/Custom Scenery/z_autoortho/textures"
+    #path = "/home/mkubilus/Software/xplane/autoortho/Custom Scenery/zAutoOrtho/textures"
     print(CFG.paths)
-    path = os.path.join(CFG.paths.scenery_path, 'z_autoortho', 'textures')
+    path = os.path.join(CFG.paths.scenery_path, 'zAutoOrtho', 'textures')
     print(f"Testing against {path}")
 
     @task(1)

--- a/autoortho/test_autoortho.py
+++ b/autoortho/test_autoortho.py
@@ -39,15 +39,15 @@ def pushd(new_dir):
 def scenery_dir(tmpdir):
     scenery_dir = os.path.join(tmpdir, 'Custom Scenery')
     structure = [
-        os.path.join(scenery_dir, 'z_autoortho', 'z_ao_test', 'Earth nav data'),
-        os.path.join(scenery_dir, 'z_autoortho', 'z_ao_test', 'terrain'),
-        os.path.join(scenery_dir, 'z_autoortho', 'z_ao_test', 'textures'),
+        os.path.join(scenery_dir, 'zAutoOrtho', 'z_ao_test', 'Earth nav data'),
+        os.path.join(scenery_dir, 'zAutoOrtho', 'z_ao_test', 'terrain'),
+        os.path.join(scenery_dir, 'zAutoOrtho', 'z_ao_test', 'textures'),
     ]
 
     for d in structure:
         os.makedirs(d)
 
-    return os.path.join(scenery_dir, 'z_autoortho', 'z_ao_test')
+    return os.path.join(scenery_dir, 'zAutoOrtho', 'z_ao_test')
 
 #@pytest.fixture(scope="module")
 #def mount(tmpdir_factory):

--- a/autoortho/test_downloader.py
+++ b/autoortho/test_downloader.py
@@ -23,8 +23,8 @@ def scenery_v1(tmpdir):
     
     os.makedirs(os.path.join(scenery_dir, 'z_test_00', 'stuff'))
     os.makedirs(os.path.join(scenery_dir, 'z_test_01', 'stuff'))
-    os.makedirs(os.path.join(scenery_dir, 'z_autoortho', '_textures'))
-    os.makedirs(os.path.join(scenery_dir, 'z_autoortho', 'textures'))
+    os.makedirs(os.path.join(scenery_dir, 'zAutoOrtho', '_textures'))
+    os.makedirs(os.path.join(scenery_dir, 'zAutoOrtho', 'textures'))
    
     info['ortho_dirs'] = [
             os.path.join(scenery_dir, 'z_test_00'),
@@ -32,7 +32,7 @@ def scenery_v1(tmpdir):
             os.path.join(scenery_dir, 'z_test_02'),
     ]
 
-    with open(os.path.join(scenery_dir, 'z_autoortho', 'test_info.json'), 'w') as h:
+    with open(os.path.join(scenery_dir, 'zAutoOrtho', 'test_info.json'), 'w') as h:
         h.write(json.dumps(info))
 
     return scenery_dir
@@ -62,14 +62,14 @@ def test_v1_upgrade(scenery_v1):
     extracts = os.listdir(scenery_v1)
     extracts.sort()
     assert extracts == [
-            'yAutoOrtho_Overlays', 'z_autoortho'
+            'yAutoOrtho_Overlays', 'zAutoOrtho'
     ]
 
-    scenery = os.listdir(os.path.join(scenery_v1, "z_autoortho", "scenery"))
+    scenery = os.listdir(os.path.join(scenery_v1, "zAutoOrtho", "scenery"))
     scenery.sort()
     assert scenery == ['z_ao_test']
 
-    orthodetails = os.listdir(os.path.join(scenery_v1, "z_autoortho"))
+    orthodetails = os.listdir(os.path.join(scenery_v1, "zAutoOrtho"))
     orthodetails.sort()
     assert orthodetails == ['scenery', 'test_info.json']
 
@@ -101,14 +101,14 @@ def test_upgrade(tmpdir):
     extracts = os.listdir(scenery_dir)
     extracts.sort()
     assert extracts == [
-            'yAutoOrtho_Overlays', 'z_autoortho'
+            'yAutoOrtho_Overlays', 'zAutoOrtho'
     ]
 
-    scenery = os.listdir(os.path.join(scenery_dir, "z_autoortho", "scenery"))
+    scenery = os.listdir(os.path.join(scenery_dir, "zAutoOrtho", "scenery"))
     scenery.sort()
     assert scenery == ['z_ao_test']
 
-    orthodetails = os.listdir(os.path.join(scenery_dir, "z_autoortho"))
+    orthodetails = os.listdir(os.path.join(scenery_dir, "zAutoOrtho"))
     orthodetails.sort()
     assert orthodetails == ['scenery', 'test_info.json']
 
@@ -163,21 +163,21 @@ def test_fetch(tmpdir):
     extracts = os.listdir(scenery_dir)
     extracts.sort()
     assert extracts == [
-            'yAutoOrtho_Overlays', 'z_autoortho'
+            'yAutoOrtho_Overlays', 'zAutoOrtho'
     ]
     #assert extracts == [
-    #        'yAutoOrtho_Overlays', 'z_autoortho'
+    #        'yAutoOrtho_Overlays', 'zAutoOrtho'
     #]
 
-    scenery = os.listdir(os.path.join(scenery_dir, "z_autoortho", "scenery"))
+    scenery = os.listdir(os.path.join(scenery_dir, "zAutoOrtho", "scenery"))
     scenery.sort()
     assert scenery == ['z_ao_test']
 
-    scenery = os.listdir(os.path.join(scenery_dir, "z_autoortho", "scenery", "z_ao_test"))
+    scenery = os.listdir(os.path.join(scenery_dir, "zAutoOrtho", "scenery", "z_ao_test"))
     scenery.sort()
     assert scenery == ['Earth nav data', 'ORTHO_SETUP.md', 'terrain', 'textures']
 
-    orthodetails = os.listdir(os.path.join(scenery_dir, "z_autoortho"))
+    orthodetails = os.listdir(os.path.join(scenery_dir, "zAutoOrtho"))
     orthodetails.sort()
     assert orthodetails == ['scenery', 'test_info.json']
 
@@ -252,13 +252,13 @@ def test_bad_zip(tmpdir):
     extracts = os.listdir(scenery_dir)
     extracts.sort()
     assert extracts == [
-            'yAutoOrtho_Overlays', 'z_autoortho'
+            'yAutoOrtho_Overlays', 'zAutoOrtho'
     ]
     #assert extracts == [
-    #        'yAutoOrtho_Overlays', 'z_autoortho'
+    #        'yAutoOrtho_Overlays', 'zAutoOrtho'
     #]
 
-    scenery = os.listdir(os.path.join(scenery_dir, "z_autoortho", "scenery"))
+    scenery = os.listdir(os.path.join(scenery_dir, "zAutoOrtho", "scenery"))
     scenery.sort()
     assert scenery == ['z_ao_test']
 

--- a/autoortho/xp_udp.py
+++ b/autoortho/xp_udp.py
@@ -10,8 +10,8 @@ def reload_obj(path):
   
   cmd = b"OBJN"
   idx = 1
-  #string = "Custom Scenery/z_autoortho/Earth nav data/+40-120/+40-112.dsf"
-  string = os.path.join("Custom Scenery/z_autoortho", path)
+  #string = "Custom Scenery/zAutoOrtho/Earth nav data/+40-120/+40-112.dsf"
+  string = os.path.join("Custom Scenery/zAutoOrtho", path)
   message = struct.pack("<4sxi500s", cmd, idx, string.encode('utf-8'))
 
   sock.sendto(message, ("127.0.01", 49000))

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,1 +1,22 @@
-../README.md
+# AutoOrtho - Automatic orthophotos for X-Plane
+
+Orthophoto satellite imagery is something that has been supported by X-Plane
+for some time.  However, this requires a large commitment of storage
+space and patience since imagery would need to be downloaded and prepared
+ahead of time.
+
+This project provides a way to retrieve only the satellite imagery you need as you fly,
+wherever you choose to in the world!
+
+---
+Please read and familiarize yourself with the documentation before asking
+questions!!
+---
+
+_No really, read the documentation before asking questions, likely this is
+already covered._
+
+* Documentation: (https://kubilus1.github.io/autoortho/)
+* FAQ: (https://kubilus1.github.io/autoortho/faq/)
+* Discussions and help: (https://github.com/kubilus1/autoortho/discussions)
+* Latest release: (https://github.com/kubilus1/autoortho/releases/latest)

--- a/docs/details.md
+++ b/docs/details.md
@@ -98,7 +98,7 @@ coastline PNG files that must be preserved.  These are simply passed through whe
 
 You can take advantage of this setup for your own scenery that you have
 packaged:
-* Place your scenery directory in `Custom Scenery/z_autoortho/scenery`
+* Place your scenery directory in `Custom Scenery/zAutoOrtho/scenery`
 
 When execute Autoortho will detect directories in that scenery dir and mount these in your configured `Custom Scenery` directory.
 

--- a/docs/scenery.md
+++ b/docs/scenery.md
@@ -40,7 +40,7 @@ yAutoOrtho_Overlays
 z_ao_aus_pac
 z_ao_eur
 z_ao_na
-z_autoortho
+zAutoOrtho
 zzz_global_scenery
 ```
 


### PR DESCRIPTION
Changed z_autoortho folder name to ZAutoOrtho to be consistent with YAutoOrtho_Overlays so that other setup programs can reference both folders as *AutoOrtho*