### PR TITLE
Add Yandex map

### DIFF
--- a/autoortho/aoconfig.py
+++ b/autoortho/aoconfig.py
@@ -72,7 +72,7 @@ min_zoom = 12
 # stutters.  Lower numbers will be more responsive at the expense of
 # ocassional low quality tiles.
 maxwait = 0.5
-maptypes = ['Null', 'BI', 'NAIP', 'EOX', 'USGS', 'Firefly']
+maptypes = ['Null', 'BI', 'NAIP', 'EOX', 'USGS', 'Firefly', 'YNDX']
 fetch_threads = 32 
 
 [pydds]

--- a/autoortho/config_ui.py
+++ b/autoortho/config_ui.py
@@ -97,7 +97,7 @@ class ConfigUI(object):
         scenery_path = self.cfg.paths.scenery_path
         showconfig = self.cfg.general.showconfig
         maptype = self.cfg.autoortho.maptype_override
-        maptypes = ['', 'BI', 'NAIP', 'EOX', 'USGS', 'Firefly'] 
+        maptypes = ['', 'BI', 'NAIP', 'EOX', 'USGS', 'Firefly', 'YNDX']
 
         sg.theme('DarkAmber')
 

--- a/autoortho/getortho.py
+++ b/autoortho/getortho.py
@@ -271,6 +271,7 @@ class Chunk(object):
             "NAIP": f"http://naip.maptiles.arcgis.com/arcgis/rest/services/NAIP/MapServer/tile/{self.zoom}/{self.row}/{self.col}",
             "USGS": f"https://basemap.nationalmap.gov/arcgis/rest/services/USGSImageryOnly/MapServer/tile/{self.zoom}/{self.row}/{self.col}",
             "FIREFLY": f"https://fly.maptiles.arcgis.com/arcgis/rest/services/World_Imagery_Firefly/MapServer/tile/{self.zoom}/{self.row}/{self.col}"
+            "YNDX": f"https://sat{server_num+1:02d}.maps.yandex.net/tiles?l=sat&v=3.1814.0&x={self.col}&y={self.row}&z={self.zoom}"
         }
        
 


### PR DESCRIPTION
Adds Yandex maps as “YNDX”. Not the best in terms of image quality, but may be preferable for Russian users (download speed, unmetered traffic for maps on mobile data)